### PR TITLE
SIG SEGFAULT silenced on line 18

### DIFF
--- a/bashcheck
+++ b/bashcheck
@@ -15,7 +15,7 @@ else
 	echo -e "\033[92mNot vulnerable to CVE-2014-7169 (taviso bug)\033[39m"
 fi
 
-bash -c "true $(printf '<<EOF %.0s' {1..79})" 2>/dev/null
+{bash -c "true $(printf '<<EOF %.0s' {1..79})"} > /dev/null 2>&1
 if [ $? != 0 ]; then
 	echo -e "\033[91mVulnerable to CVE-2014-7186 (redir_stack bug)\033[39m"
 else


### PR DESCRIPTION
Using { } around bash command, I silenced the SIGSEGFAULT message when received.

Just for sake of having a nicer output.
