### PR TITLE
fix false negative for CVE-2014-7169 (taviso bug)

### DIFF
--- a/bashcheck
+++ b/bashcheck
@@ -15,7 +15,7 @@ else
 fi
 
 cd /tmp;rm echo 2>/dev/null
-X='() { function a a>\' $bash -c echo 2>/dev/null > /dev/null
+env X='() { function a a>\' $bash -c echo 2>/dev/null > /dev/null
 if [ -e echo ]; then
 	echo -e "\033[91mVulnerable to CVE-2014-7169 (taviso bug)\033[39m"
 else


### PR DESCRIPTION
I fixed a test after spotting this weird result on SUSE Linux Enterprise Server 11:
# ./bashcheck

Testing /bin/bash ...
GNU bash, version 3.2.51(1)-release (x86_64-suse-linux-gnu)
Vulnerable to CVE-2014-6271 (original shellshock)
Not vulnerable to CVE-2014-7169 (taviso bug)
Vulnerable to CVE-2014-7186 (redir_stack bug)
Test for CVE-2014-7187 not reliable without address sanitizer
./bashcheck: line 42: 10469 Segmentation fault      $bash -c "f(){ x(){ _;};x(){ _;}<<a;}"
Vulnerable to CVE-2014-6277 (lcamtuf bug #1) [no patch]
Variable function parser still active, maybe vulnerable to unknown parser bugs
