### PR TITLE
Fix test for CVE-2014-6277 to be a function import test from environment...

### DIFF
--- a/bashcheck
+++ b/bashcheck
@@ -40,21 +40,13 @@ else
 fi
 
 if ! $(env x='() { x() { _; }; x() { _; } <<a; }' $bash -c :); then
-	echo -e "\033[91mVulnerable to CVE-2014-6277 (lcamtuf bug #1) [no prefix/suffix]\033[39m"
-elif ! $(env BASH_FUNC_x%%='() { x() { _; }; x() { _; } <<a; }' $bash -c : 2>/dev/null); then
-	echo -e "\033[91mVulnerable to CVE-2014-6277 (lcamtuf bug #1) [prefix/%%-suffix]\033[39m"
-elif ! $(env 'BASH_FUNC_x()'='() { x() { _; }; x() { _; } <<a; }' $bash -c : 2>/dev/null); then
-	echo -e "\033[91mVulnerable to CVE-2014-6277 (lcamtuf bug #1) [prefix/()-suffix]\033[39m"
+	echo -e "\033[91mVulnerable to CVE-2014-6277 (lcamtuf bug #1)\033[39m"
 else
 	echo -e "\033[92mNot vulnerable to CVE-2014-6277 (lcamtuf bug #1)\033[39m"
 fi
 
 if [ -n "$(env x='() { _;}>_[$($())] { echo x;}' $bash -c : 2>/dev/null)" ]; then
-	echo -e "\033[91mVulnerable to CVE-2014-6278 (lcamtuf bug #2) [no prefix/suffix]\033[39m"
-elif [ -n "$(env BASH_FUNC_x%%='() { _;}>_[$($())] { echo x;}' $bash -c : 2>/dev/null)" ]; then
-	echo -e "\033[91mVulnerable to CVE-2014-6278 (lcamtuf bug #2) [prefix/%%-suffix]\033[39m"
-elif [ -n "$(env 'BASH_FUNC_x()'='() { _;}>_[$($())] { echo x;}' $bash -c : 2>/dev/null)" ]; then
-	echo -e "\033[91mVulnerable to CVE-2014-6278 (lcamtuf bug #2) [prefix/()-suffix]\033[39m"
+	echo -e "\033[91mVulnerable to CVE-2014-6278 (lcamtuf bug #2)\033[39m"
 else
 	echo -e "\033[92mNot vulnerable to CVE-2014-6278 (lcamtuf bug #2)\033[39m"
 fi

--- a/bashcheck
+++ b/bashcheck
@@ -39,9 +39,12 @@ else
 	echo -e "\033[96mTest for CVE-2014-7187 not reliable without address sanitizer\033[39m"
 fi
 
-$($bash -c "f(){ x(){ _;};x(){ _;}<<a;}" 2>/dev/null)
-if [ $? != 0 ]; then
-	echo -e "\033[91mVulnerable to CVE-2014-6277 (lcamtuf bug #1) [no patch]\033[39m"
+if ! $(env x='() { x() { _; }; x() { _; } <<a; }' $bash -c :); then
+	echo -e "\033[91mVulnerable to CVE-2014-6277 (lcamtuf bug #1) [no prefix/suffix]\033[39m"
+elif ! $(env BASH_FUNC_x%%='() { x() { _; }; x() { _; } <<a; }' $bash -c : 2>/dev/null); then
+	echo -e "\033[91mVulnerable to CVE-2014-6277 (lcamtuf bug #1) [prefix/%%-suffix]\033[39m"
+elif ! $(env 'BASH_FUNC_x()'='() { x() { _; }; x() { _; } <<a; }' $bash -c : 2>/dev/null); then
+	echo -e "\033[91mVulnerable to CVE-2014-6277 (lcamtuf bug #1) [prefix/()-suffix]\033[39m"
 else
 	echo -e "\033[92mNot vulnerable to CVE-2014-6277 (lcamtuf bug #1)\033[39m"
 fi


### PR DESCRIPTION
....

Bash 4.3.28 currently does crash with the example scripts for
both CVE-2014-6277 and CVE-2014-6278 with no patch[1], but it
will not run any code from them without specially setting up
the environment to use the prefixing. Both CVE are documented
as specifically environment issues; if you can pass bad code
directly to bash -c then the attacker has already won.

The check must involve the environment or it will needlessly scare
users who have deployed appropriate mitigations. For example,
on FreeBSD (and NetBSD) we have disabled all function importing from
the environment. So this test passes fine on our bash versions.

The syntax used here is to check the return value to see if it
crashed, while hiding the core dump messages. There's no
code execution proven for CVE-2014-6277 yet so there is no
output that can be checked against.

Switch the test to more closely match the examples from the
disclosure [2].

[1] http://www.openwall.com/lists/oss-security/2014/10/01/25
[2] http://lcamtuf.blogspot.de/2014/10/bash-bug-how-we-finally-cracked.html
