### PR TITLE
BusyBox 'mktemp'-fixing

### DIFF
--- a/bashcheck
+++ b/bashcheck
@@ -12,7 +12,9 @@ good() {
 	echo -e "\033[92mNot vulnerable to $1\033[39m"
 }
 
-tmpdir=`mktemp -d -t tmp.XXXXXXXX`
+tmpdir=`mktemp -d -t /bashcheck.tmp.XXXXXXXX 2>/dev/nul`
+[ -z "$tmpdir" ] && tmpdir=`mktemp -d /tmp/bashcheck.tmp.XXXXXXXX 2>/dev/nul`
+[ -z "$tmpdir" ] && tmpdir=/tmp/bashcheck.tmp.`date  "+%s.%N"` && mkdir $tmpdir
 
 [ -n "$1" ] && bash=$(which $1) || bash=$(which bash)
 echo -e "\033[95mTesting $bash ..."

--- a/bashcheck
+++ b/bashcheck
@@ -12,8 +12,8 @@ good() {
 	echo -e "\033[92mNot vulnerable to $1\033[39m"
 }
 
-tmpdir=`mktemp -d -t /bashcheck.tmp.XXXXXXXX 2>/dev/nul`
-[ -z "$tmpdir" ] && tmpdir=`mktemp -d /tmp/bashcheck.tmp.XXXXXXXX 2>/dev/nul`
+tmpdir=`mktemp -d -t /bashcheck.tmp.XXXXXXXX 2>/dev/null`
+[ -z "$tmpdir" ] && tmpdir=`mktemp -d /tmp/bashcheck.tmp.XXXXXXXX 2>/dev/null`
 [ -z "$tmpdir" ] && tmpdir=/tmp/bashcheck.tmp.`date  "+%s.%N"` && mkdir $tmpdir
 
 [ -n "$1" ] && bash=$(which $1) || bash=$(which bash)


### PR DESCRIPTION
In the BusyBox-Kernel (for instance on QNAP-NAS) the 'mktemp'-command have no support for the '-t'-switch and right problems to create subdirs in some dircetorys.
