### PR TITLE
workaround for versions of grep without -q (quiet) option

### DIFF
--- a/bashcheck
+++ b/bashcheck
@@ -55,7 +55,7 @@ fi
 
 $($bash -c "true $(printf '<<EOF %.0s' {1..80})" 2>$tmpdir/bashcheck.tmp)
 ret=$?
-grep -q AddressSanitizer $tmpdir/bashcheck.tmp
+grep AddressSanitizer $tmpdir/bashcheck.tmp >/dev/null 2>&1
 if [ $? == 0 ] || [ $ret == 139 ]; then
 	warn "CVE-2014-7186 (redir_stack bug)"
 else


### PR DESCRIPTION
Please be gentle; this is my first pull request. :-)  Also, typo in my original commit - it's supposed to say that this is a workaround for versions _without_ -q, not _with_ -q.
